### PR TITLE
docs: API inventory + GFV topology for Python migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Tests target the legacy Node runtime and need a configured test database. The Do
 ## More detail
 
 - Docker images and scripts: **[dockerfiles/README.md](dockerfiles/README.md)**
+- Python rewrite / API I/O inventory: **[docs/migration/](docs/migration/)**
 - Multi-agent orchestration notes: **[AGENTS.md](AGENTS.md)**
 
 ## License

--- a/docs/migration/ADR-001-userReports-behavior.md
+++ b/docs/migration/ADR-001-userReports-behavior.md
@@ -1,0 +1,51 @@
+# ADR-001: `GET /users/:id/reports` behavior
+
+## Status
+
+**Accepted (inventory truth)** — decision on fix vs bug-for-bug deferred.
+
+## Context
+
+Multi-reviewer comparison (independent Grok report, Fable Max, Codex Sol Ultra) found a mismatch between intended “user report history” and implementation.
+
+## Decision (documentation)
+
+Document **actual** behavior as the production contract until product decides otherwise.
+
+## Actual behavior (code)
+
+Source: `api/controllers/UsersController.js` → `userReports`.
+
+1. Load access token from `?accessToken=`.
+2. Forbid unless `accessToken.userId == :id` (path).
+3. Run:
+
+```sql
+SELECT * FROM reports r
+ORDER BY r."createdAt" DESC
+LIMIT $offset OFFSET $limit;
+
+SELECT COUNT(r.id) AS total FROM reports r;
+```
+
+**No `WHERE "userId" = :id`.**  
+Items and `count` are **global** (paginated latest reports system-wide), not filtered to that user.
+
+Tests only create reports for one user, so they do not expose the leak.
+
+## Options for Python rewrite
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Bug-for-bug** | Matches live clients that may rely on global feed | Continues privacy leak |
+| **B. Fix filter by userId** | Correct semantics | Breaks any client expecting global list |
+| **C. New path for correct history; keep old as-is** | Safest if clients are unknown | Two endpoints to maintain |
+
+## Default recommendation
+
+**C** if any external client is uncertain; otherwise product call after traffic capture.
+
+## Consequences
+
+- Inventory and OpenAPI must not claim “user’s reports only” without an ADR updating this file.
+- Characterization tests must use **two users with reports** to prove filter behavior.

--- a/docs/migration/ADR-002-ili-rule.md
+++ b/docs/migration/ADR-002-ili-rule.md
@@ -1,0 +1,26 @@
+# ADR-002: ILI classification rule
+
+## Status
+
+**Accepted** — code is source of truth.
+
+## Decision
+
+A report is ILI when **any** of the submitted symptoms intersects the configured ILI set.
+
+## Rule (runtime)
+
+Source: `api/services/ReportService.js` create path; `config/symptoms.js`.
+
+```text
+ILISymptoms = ["fever", "cough", "sore-throat"]
+isILI = non-empty intersection(report.symptoms, ILISymptoms)
+```
+
+**Not** “fever AND (cough OR sore-throat)”.
+
+## Consequences
+
+- Python must implement **any-of** matching against the same slug set (or equivalent config).
+- External write-ups that use classic WHO-style “fever + respiratory” must not override this without a product decision and mobile impact review.
+- DB triggers / summary tables may also encode ILI counting; re-check `db/3_reports_procedure.sql` and `db/16_update_trigger_on_tables.sql` during schema port.

--- a/docs/migration/ADR-003-gfv-history-reexport.md
+++ b/docs/migration/ADR-003-gfv-history-reexport.md
@@ -1,0 +1,33 @@
+# ADR-003: GFV historical re-export (option A)
+
+**Status:** Accepted  
+**Date:** 2026-07-31  
+**Owner:** project owner  
+
+## Context
+
+Production GFV weekly snapshots are corrupted by single-arg `crosstab` misuse (see [GFV_F1_CROSSTAB_VERIFY.md](./GFV_F1_CROSSTAB_VERIFY.md)): stored symptom flags and `is_ili` are count-thresholds, not named symptoms. Raw `sicksense` tables still hold enough data to recompute correct weeks.
+
+Two strategies after a fixed extractor ships:
+
+| Option | Meaning |
+|--------|---------|
+| **A** | Rebuild **all** historical weeks from raw data and publish corrected history |
+| **B** | Leave old weeks as-is; only new weeks use fixed logic |
+
+## Decision
+
+**Plan for A** — historical **re-export / backfill** of all GFV weeks from raw `sicksense` data when the multi-outlet export (Phase B) is ready.
+
+## Consequences
+
+- Phase B must include a **replay job** (all week windows since first GFV week ≈ 2021-08), not only a cron for “last week”.
+- Need explicit **ILI + symptom vocabulary** policy before replay (catalog English + Thai free-text mapping); otherwise rebuilt history is still wrong for modern reports.
+- Cutover should **stage** corrected weeks (shadow compare → swap) so a bad replay does not wipe the live feed without rollback.
+- Consumers of old weeks (if any) will see **changed** SurveyCount / IsILI / symptom flags after republish — document as intentional correction, not silent drift.
+- Mobile API rewrite (Phase A) is **not** blocked; replay runs in Phase B.
+
+## Non-goals
+
+- Fixing production Django sync before Phase B (optional hot-fix is separate and not required by this ADR).
+- Changing the public path `/globalfluview/api/...` as part of A.

--- a/docs/migration/API_INVENTORY.md
+++ b/docs/migration/API_INVENTORY.md
@@ -429,19 +429,30 @@ So this is **not** “this user’s history”; it is a **system-wide recent fee
 
 ---
 
-## 11. Not in this repository (do not invent)
+## 11. Not in this repository (separate service)
 
-### Global Flu View–style paths
+### Global Flu View (proven separate Django app)
 
-Examples cited externally: `/globalfluview/api/weeks/`, `/globalfluview/api/surveys/{week_id}/`.
+Sibling repo: `opendream/sicksense_globalfluview` (local `../sicksense_globalfluview`).  
+Live base: `https://api.sicksense.org/globalfluview/` (same host as Sails; nginx path → uWSGI).  
+Full write-up: [GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md).
+
+| Method | Path | Auth | Envelope |
+|--------|------|------|----------|
+| GET | `/globalfluview/api/weeks/` | HTTP Basic (Django) | `{Iwops:"v2", Resource, Data}` |
+| GET | `/globalfluview/api/surveys/{week_id}/` | HTTP Basic | same |
+| GET | `/globalfluview/api/participants/{week_id}/` | HTTP Basic | same |
 
 | Fact | Status |
 |------|--------|
-| Present in this codebase | **No** (grep empty; blueprints off) |
-| Served by this Sails app | **Unproven** |
-| Live host auth | May be **host-wide** basic auth (probe carefully); not proof the path is implemented here |
+| Present in this Sails codebase | **No** |
+| Served by this Sails app | **No** — separate Django process + DB `globalfluview` |
+| Live host | **Yes** — path mount on `api.sicksense.org` |
+| DNS `api_globalfluview.sicksense.org` | **NXDOMAIN** (planned vhost never shipped) |
+| Mobile FastAPI early phases | **Keep live Django**; do not break sync |
+| Final unified codebase | **In scope** as multi-outlet export (Phase B) — see [GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md) |
 
-**Action:** resolve via nginx/upstream config and logs before adding any FastAPI routes.
+**Action:** preserve main schema compatibility for `sync_from_sicksense` until Phase B ports GFV into the new service. Early mobile inventory can omit GFV route tables; Phase B OpenAPI/outlet module must include them.
 
 ### Apiary-only / stale
 

--- a/docs/migration/API_INVENTORY.md
+++ b/docs/migration/API_INVENTORY.md
@@ -2,7 +2,10 @@
 
 **Sources:** `config/routes.js`, `config/policies.js`, controllers under `api/controllers/`, services, `apiary.apib`, mocha tests.
 
-**Envelope:** see [RESPONSE_ENVELOPE.md](./RESPONSE_ENVELOPE.md).
+**Review:** Corrected after independent Grok report + Fable Max + Codex Sol Ultra (see [REVIEW_SYNTHESIS.md](./REVIEW_SYNTHESIS.md)).
+
+**Envelope:** see [RESPONSE_ENVELOPE.md](./RESPONSE_ENVELOPE.md).  
+**ADRs:** [userReports](./ADR-001-userReports-behavior.md), [ILI rule](./ADR-002-ili-rule.md).
 
 **Legend**
 
@@ -25,26 +28,31 @@
 | **Auth** | public |
 | **Controller** | `UsersController.create` |
 
-**Input (body JSON)**
+**Dual identity (important)**  
+- Device row in `users` often uses synthetic email `{uuid}@sicksense.com` (password derived from uuid).  
+- Optional real **Sicksense account** email/password lives in `sicksense` + link table `sicksense_users`.  
+- If `uuid` omitted, code derives uuid from email local-part (legacy pre-4.2 TODO).
+
+**Input (body JSON)** — validation as implemented (`validate()`)
 
 | Field | Required | Notes |
 |-------|----------|--------|
-| `uuid` | soft | Device id; if missing, derived from email local-part (legacy ≤4.1) |
-| `email` | for sicksense account | Real email when creating/linking sicksense ID |
-| `password` | with real email | Account password |
-| `tel` | yes (validated) | Phone |
-| `gender` | yes | `male` / `female` |
-| `birthYear` | yes | CE year |
-| `address.subdistrict` | yes | |
-| `address.district` | yes | |
-| `address.city` | yes | |
-| `location.latitude` / `longitude` | optional | GPS; stored as Point 4326 |
+| `email` | **yes** | Valid email (also used as sicksense ID when “real” email path) |
+| `password` | **yes** | Length 8–64 |
+| `uuid` | no | Device id; commented-out required check (pre-4.2 apps) |
+| `tel` | no* | Used if present; not hard-required in validate() block |
+| `gender` | no | If present: `male` \| `female` |
+| `birthYear` | no | If present: int 1900…current year |
+| `address` | no | If present: subdistrict, district, city all required + must match `locations` |
+| `location` | no | If present: lat/lon required and in range |
 | `platform` | optional | body or query; default `doctormeios` |
 | `deviceToken` | optional | Push device id; `""` clears |
 | `subscribe` | optional | email subscription after register |
 
+\*Demographics may still be written as undefined if omitted — clients usually send them.
+
 **Output (200)**  
-User JSON (`formattedUser` / `getUserJSON`) plus `accessToken` (and often `deviceToken`).
+User JSON (`formattedUser` / `getUserJSON`) plus `accessToken` (and often `deviceToken`). Linked sicksense email may replace device email in the JSON.
 
 **Errors**  
 400 validation; 409 device already registered / email taken; 403 / 500 as coded.
@@ -92,15 +100,34 @@ Updated user JSON.
 
 ---
 
-### `GET /users/:id/reports` — user report history
+### `GET /users/:id/reports` — report list (auth scoped to user, **data not filtered**)
 
 | | |
 |--|--|
-| **Auth** | accessToken |
+| **Auth** | accessToken; token’s `userId` must equal path `:id` |
 | **Controller** | `UsersController.userReports` |
+| **ADR** | [ADR-001](./ADR-001-userReports-behavior.md) |
 
-**Input:** path `id`; query `accessToken`, `offset` (default 0), `limit` (default 10).  
-**Output:** paginated reports for that user (report JSON list).
+**Input:** path `id`; query `accessToken`, `offset` (default 0), `limit` (default 10).
+
+**Actual behavior (parity-critical)**  
+SQL selects **all** reports ordered by `createdAt DESC` with limit/offset, and **global** `COUNT(*)`.  
+There is **no** `WHERE "userId" = :id`.  
+
+So this is **not** “this user’s history”; it is a **system-wide recent feed**, gated only by “token belongs to `:id`”.
+
+**Output:**
+
+```json
+{
+  "reports": {
+    "count": "<global total>",
+    "items": [ /* report JSON + symptoms */ ]
+  }
+}
+```
+
+**Rewrite decision required:** bug-for-bug vs filter by user vs new path (see ADR-001).
 
 ---
 
@@ -223,9 +250,21 @@ Updated user JSON.
 | `moreInfo` | optional | text |
 | `platform` | optional | body/query |
 
-**Server-derived:** `userId`, address from user, `location_id` from address lookup, `isILI` from symptom config, `is_anonymous` / `sicksense_id` from account link, week/year.
+**Server-derived**
 
-**Output:** report JSON (`ReportService.getReportJSON`).
+| Field | Rule |
+|-------|------|
+| `userId` | from token user |
+| address fields | from user profile |
+| `location_id` | lookup `locations` by address |
+| `isILI` | **any** of symptoms ∈ `{fever, cough, sore-throat}` — [ADR-002](./ADR-002-ili-rule.md) |
+| `is_anonymous` | `true` unless user has `sicksenseId` **and** `isVerified` |
+| `sicksense_id` | if linked |
+| `year` / `week` | from `moment(startedAt).week()` (locale-sensitive) |
+| geom | from GPS location or address-derived coords |
+
+**Output:** report JSON (`ReportService.getReportJSON`).  
+**Side effects:** insert report + reportssymptoms; **plpgsql triggers** update weekly summary tables.
 
 ---
 
@@ -275,7 +314,15 @@ Updated user JSON.
 | `date` | optional moment date |
 | `includeReports` | optional extra payload |
 
-**Output:** aggregated ILI / summary stats for location + period (fine/sick/ILI counts, charts data). Exact keys in controller return object — preserve in OpenAPI later.
+**Output:** aggregated ILI / summary stats for location + period (fine/sick/ILI counts, charts data from `ililog` BOE + sicksense series). Exact keys in controller return object — preserve in OpenAPI later.
+
+### `GET /dashboard` — **implemented, not in routes.js**
+
+| | |
+|--|--|
+| **Controller** | `DashboardController.index` |
+| **Evidence** | controller + tests/apiary mention |
+| **Status** | **OPEN** — same class of anomaly as `/login` and `/reports` |
 
 ---
 
@@ -379,6 +426,28 @@ Updated user JSON.
 |--------|------|--------|
 | GET | `/` | Homepage view (EJS), not API envelope |
 | OPTIONS | `/*` | CORS preflight 200 |
+
+---
+
+## 11. Not in this repository (do not invent)
+
+### Global Flu View–style paths
+
+Examples cited externally: `/globalfluview/api/weeks/`, `/globalfluview/api/surveys/{week_id}/`.
+
+| Fact | Status |
+|------|--------|
+| Present in this codebase | **No** (grep empty; blueprints off) |
+| Served by this Sails app | **Unproven** |
+| Live host auth | May be **host-wide** basic auth (probe carefully); not proof the path is implemented here |
+
+**Action:** resolve via nginx/upstream config and logs before adding any FastAPI routes.
+
+### Apiary-only / stale
+
+| Path | Notes |
+|------|--------|
+| `GET /reports/{id}` | In apiary; **no** matching controller action wired |
 
 ---
 

--- a/docs/migration/API_INVENTORY.md
+++ b/docs/migration/API_INVENTORY.md
@@ -1,0 +1,431 @@
+# API inventory (high-level inputs / outputs)
+
+**Sources:** `config/routes.js`, `config/policies.js`, controllers under `api/controllers/`, services, `apiary.apib`, mocha tests.
+
+**Envelope:** see [RESPONSE_ENVELOPE.md](./RESPONSE_ENVELOPE.md).
+
+**Legend**
+
+| Auth | Meaning |
+|------|---------|
+| public | No token |
+| accessToken | `?accessToken=` → user session (`tokenAuth`) |
+| optionalAccessToken | `?accessToken=` optional (`optionalTokenAuth`) |
+| sharedToken | `?token=` server shared secret (`sharedToken`) |
+| mailgunToken | `?token=` mailgun webhook secret |
+
+---
+
+## 1. Users & registration
+
+### `POST /users` — register (device ± sicksense account)
+
+| | |
+|--|--|
+| **Auth** | public |
+| **Controller** | `UsersController.create` |
+
+**Input (body JSON)**
+
+| Field | Required | Notes |
+|-------|----------|--------|
+| `uuid` | soft | Device id; if missing, derived from email local-part (legacy ≤4.1) |
+| `email` | for sicksense account | Real email when creating/linking sicksense ID |
+| `password` | with real email | Account password |
+| `tel` | yes (validated) | Phone |
+| `gender` | yes | `male` / `female` |
+| `birthYear` | yes | CE year |
+| `address.subdistrict` | yes | |
+| `address.district` | yes | |
+| `address.city` | yes | |
+| `location.latitude` / `longitude` | optional | GPS; stored as Point 4326 |
+| `platform` | optional | body or query; default `doctormeios` |
+| `deviceToken` | optional | Push device id; `""` clears |
+| `subscribe` | optional | email subscription after register |
+
+**Output (200)**  
+User JSON (`formattedUser` / `getUserJSON`) plus `accessToken` (and often `deviceToken`).
+
+**Errors**  
+400 validation; 409 device already registered / email taken; 403 / 500 as coded.
+
+**Side effects**  
+Insert `users`, maybe `sicksense` + `sicksense_users`, `accesstoken`, `devices`; may send verification email.
+
+---
+
+### `POST /users/:id` — update profile
+
+| | |
+|--|--|
+| **Auth** | accessToken (must match `:id`) |
+| **Controller** | `UsersController.update` |
+
+**Input**
+
+| Field | Source | Notes |
+|-------|--------|--------|
+| `id` | path | Must equal token user |
+| `accessToken` | query | Required by policy |
+| `gender`, `birthYear` | body | optional |
+| `address.*` | body | optional partial |
+| `location` | body | optional |
+| `password` | body | optional password change path |
+| `platform` | body/query | |
+| `deviceToken` | body | |
+| `subscribe` | body | |
+
+**Output**  
+Updated user JSON.
+
+---
+
+### `GET /users/:id` — get user
+
+| | |
+|--|--|
+| **Auth** | accessToken |
+| **Controller** | `UsersController.getUser` |
+
+**Input:** path `id`, query `accessToken`.  
+**Output:** user JSON (email may be sicksense email if linked).
+
+---
+
+### `GET /users/:id/reports` — user report history
+
+| | |
+|--|--|
+| **Auth** | accessToken |
+| **Controller** | `UsersController.userReports` |
+
+**Input:** path `id`; query `accessToken`, `offset` (default 0), `limit` (default 10).  
+**Output:** paginated reports for that user (report JSON list).
+
+---
+
+### `POST /users/:id/change-password`
+
+| | |
+|--|--|
+| **Auth** | accessToken |
+| **Controller** | `UsersController.changePassword` |
+
+**Input:** path `id`; body password fields (old/new — see controller validation).  
+**Output:** success user/status.
+
+---
+
+### `POST /users/verify`
+
+| | |
+|--|--|
+| **Auth** | public |
+| **Controller** | `UsersController.verify` |
+
+**Input:** body/token fields for email verification (onetime token flow).  
+**Output:** success; marks sicksense verified.
+
+---
+
+### `POST /users/request-verify`
+
+| | |
+|--|--|
+| **Auth** | public |
+| **Controller** | `UsersController.requestVerify` |
+
+**Input:** email / identity for resend verification.  
+**Side effect:** email.
+
+---
+
+### `POST /users/forgot-password` / `POST /users/reset-password`
+
+| | |
+|--|--|
+| **Auth** | public |
+| **Controller** | `UsersController.forgotPassword` / `resetPassword` |
+
+**Input:** email; then token + new password.  
+**Side effect:** mail + onetime token rows.
+
+---
+
+## 2. Login / account linking
+
+### `POST /connect` — link sicksense account to device
+
+| | |
+|--|--|
+| **Auth** | optionalAccessToken |
+| **Controller** | `LoginController.connect` |
+
+**Input (body)**
+
+| Field | Required |
+|-------|----------|
+| `email` | yes (email) |
+| `password` | yes (≥8) |
+| `uuid` | yes |
+| `platform` | optional |
+| `deviceToken` | optional |
+
+**Output:** user JSON with tokens after link.  
+**Errors:** 403 bad credentials / unverified account.
+
+---
+
+### `POST /unlink`
+
+| | |
+|--|--|
+| **Auth** | accessToken |
+| **Controller** | `LoginController.unlink` |
+
+**Input:** authenticated user.  
+**Output:** user JSON after unlink from sicksense account.
+
+---
+
+### `POST /login` — **implemented, not in routes.js**
+
+| | |
+|--|--|
+| **Auth** | public (controller) |
+| **Controller** | `LoginController.index` |
+| **Evidence** | `test/controllers/LoginController.test.js`, `apiary.apib` |
+| **Status** | **OPEN:** blueprints disabled and no explicit route — confirm production binding |
+
+**Input (body):** `email`, `password` (≥8), optional `deviceToken`, `platform`.  
+**Output:** user JSON + `accessToken` (+ `deviceToken` if device set).
+
+---
+
+## 3. Reports
+
+### `POST /reports` — create report
+
+| | |
+|--|--|
+| **Auth** | accessToken |
+| **Controller** | `ReportsController.create` |
+
+**Input (body)**
+
+| Field | Required | Notes |
+|-------|----------|--------|
+| `isFine` | yes | boolean |
+| `symptoms` | if not fine | array of symptom slugs |
+| `animalContact` | yes | boolean |
+| `startedAt` | yes | date; not far future; not before last week Sunday |
+| `location.latitude/longitude` | optional | GPS for report point |
+| `moreInfo` | optional | text |
+| `platform` | optional | body/query |
+
+**Server-derived:** `userId`, address from user, `location_id` from address lookup, `isILI` from symptom config, `is_anonymous` / `sicksense_id` from account link, week/year.
+
+**Output:** report JSON (`ReportService.getReportJSON`).
+
+---
+
+### `GET /reports` — list reports (geo optional)
+
+| | |
+|--|--|
+| **Auth** | public (no policy) |
+| **Controller** | `ReportsController.index` |
+| **Route** | **Not in routes.js** — tests hit `GET /reports` (**OPEN**) |
+
+**Input (query)**
+
+| Field | Notes |
+|-------|--------|
+| `offset`, `limit` | default 0 / 10 |
+| `sw`, `ne` | lat,lon pairs for bbox; both required together |
+
+**Output:**
+
+```json
+{
+  "reports": {
+    "count": 123,
+    "items": [ /* report JSON + symptoms, userAddress, locationByUserAddress */ ]
+  }
+}
+```
+
+---
+
+## 4. Dashboard
+
+### `GET /dashboard/now`
+
+| | |
+|--|--|
+| **Auth** | public |
+| **Controller** | `DashboardController.now` |
+
+**Input (query)**
+
+| Field | Notes |
+|-------|--------|
+| `city` | province/city name **or** |
+| `latitude` + `longitude` | resolve city |
+| `date` | optional moment date |
+| `includeReports` | optional extra payload |
+
+**Output:** aggregated ILI / summary stats for location + period (fine/sick/ILI counts, charts data). Exact keys in controller return object — preserve in OpenAPI later.
+
+---
+
+## 5. Notifications (admin)
+
+### `GET /notifications`
+
+| | |
+|--|--|
+| **Auth** | sharedToken |
+| **Controller** | `NotificationsController.index` |
+
+**Input:** query `token`, `offset`, `limit`.  
+**Output:** list of notification campaigns.
+
+### `POST /notifications`
+
+| | |
+|--|--|
+| **Auth** | sharedToken |
+| **Controller** | `NotificationsController.create` |
+
+**Input (body):** `published`, `body`, `link`, `gender`, `age_start`, `age_stop`, `city` (stored as province), targeting filters.  
+**Side effect:** may trigger push send when published.
+
+### `DELETE /notifications/:notification_id`  
+### `POST /notifications/:notification_id/delete`
+
+| | |
+|--|--|
+| **Auth** | sharedToken + loadNotification |
+| **Query** | `permanent` optional |
+
+**Output:** `{ }` success payload / status.
+
+---
+
+## 6. News (CMS)
+
+| Method | Path | Auth | Input | Output |
+|--------|------|------|-------|--------|
+| POST | `/news` | sharedToken | body `title`, `content` | news row |
+| GET | `/news` | public | query `offset`, `limit` | list |
+| GET | `/news/:news_id` | public | path id | news or 404 |
+| POST | `/news/:news_id` | sharedToken | body title/content | updated row |
+| DELETE | `/news/:news_id` | sharedToken | path id | empty ok / 404 |
+
+---
+
+## 7. One-time tokens
+
+### `POST /onetimetoken/validate`
+
+| | |
+|--|--|
+| **Auth** | public |
+| **Controller** | `OnetimeTokenController.validate` |
+
+**Input (body):** `token`, `type` (e.g. verify / reset).  
+**Output:** validation result payload.
+
+---
+
+## 8. Email subscription / Mailgun
+
+### `POST /email/hooks`
+
+| | |
+|--|--|
+| **Auth** | mailgunToken |
+| **Controller** | `EmailSubscriptionsController.hooks` |
+
+**Input (body):** Mailgun webhook — `event`, `recipient`, …  
+**Output:** ok / forbidden unknown event.  
+**Side effect:** update subscription / user email state.
+
+### `GET /email/send`
+
+| | |
+|--|--|
+| **Auth** | mailgunToken |
+| **Controller** | `EmailSubscriptionsController.send` |
+
+**Input:** query-driven send (see controller).  
+**Side effect:** outbound mail.
+
+---
+
+## 9. Cron / batch (HTTP)
+
+| Method | Path | Auth | Purpose | Output |
+|--------|------|------|---------|--------|
+| GET | `/cron/pushnoti` | sharedToken | Push notification batch | ok status object |
+| GET | `/cron/email_notification` | sharedToken | Email notification batch | ok / error |
+
+---
+
+## 10. Static / other
+
+| Method | Path | Notes |
+|--------|------|--------|
+| GET | `/` | Homepage view (EJS), not API envelope |
+| OPTIONS | `/*` | CORS preflight 200 |
+
+---
+
+## Entity JSON (high level)
+
+### User (`UserService.formattedUser` / `getUserJSON`)
+
+```
+id, email, tel, gender, birthYear,
+address: { subdistrict, district, city },
+location: { latitude, longitude },
+platform, isVerified, sicksenseId,
+accessToken?, deviceToken?
+```
+
+### Report (`ReportService.getReportJSON`)
+
+```
+id, isFine, isILI, animalContact, startedAt,
+address: { subdistrict, district, city },
+locationByAddress: { latitude, longitude },
+location: { latitude, longitude },
+moreInfo, createdAt, platform,
+symptoms?, userAddress?, locationByUserAddress?
+```
+
+---
+
+## Route ↔ policy matrix (from config)
+
+| Area | Policy |
+|------|--------|
+| Default `*` | public (`true`) |
+| Reports.create | tokenAuth |
+| Users update/get/userReports/changePassword | tokenAuth |
+| Users verify/forgot/reset | public |
+| Notifications * | sharedToken (+ loadNotification on destroy) |
+| News create/update/destroy | sharedToken |
+| Cron * | sharedToken |
+| Email hooks/send | mailgunToken |
+| Login connect | optionalTokenAuth |
+| Login unlink | tokenAuth |
+
+---
+
+## Endpoint count (explicit routes.js)
+
+- **Custom routes:** ~28 method+path pairs (including dual delete notification paths).
+- **Plus unresolved:** `POST /login`, `GET /reports` (tests/apiary).
+- **Blueprints:** disabled — only explicit routes (plus homepage) should be live if config is accurate.

--- a/docs/migration/DOMAIN_TABLES.md
+++ b/docs/migration/DOMAIN_TABLES.md
@@ -28,7 +28,24 @@ For Postgres 16/17 + PostGIS migration. Not a full column dump; inventory for re
 
 | Config | Role |
 |--------|------|
-| `config/symptoms.js` | Canonical symptom slugs + ILI symptom set |
-| `config/session.js` `secret` | Password hashing salt material (`password-hash-and-salt`) |
+| `config/symptoms.js` | Symptom slugs; **ILI set** = `fever`, `cough`, `sore-throat` (any match → `isILI`) |
+| `config/session.js` `secret` | Password hashing salt material (`password-hash-and-salt`) — **must match at cutover** |
 | `config/sharedTokens` | Server-to-server `token` query values |
 | `config/mailgun` | API + webhook token |
+
+## Triggers / aggregates
+
+| Artifact | Role |
+|----------|------|
+| `db/3_reports_procedure.sql` | Report-related procedures / summary updates |
+| `db/16_update_trigger_on_tables.sql` | Triggers on insert (e.g. when `is_sicksense`); per-user/week/location semantics |
+
+Re-implement or replace only after characterization tests against real rows. Week numbers use Moment’s locale week rules — not necessarily ISO.
+
+## Dual identity
+
+| Layer | Table | Typical key |
+|-------|-------|-------------|
+| Device user | `users` | `uuid@sicksense.com` synthetic email |
+| Account | `sicksense` | real email + password + `is_verify` |
+| Link | `sicksense_users` | many devices → one account |

--- a/docs/migration/DOMAIN_TABLES.md
+++ b/docs/migration/DOMAIN_TABLES.md
@@ -1,0 +1,34 @@
+# Domain ↔ tables (high level)
+
+For Postgres 16/17 + PostGIS migration. Not a full column dump; inventory for rewrite planning.
+
+| Domain | Tables (public) | Notes |
+|--------|-----------------|-------|
+| Device identity | `users` | Synthetic email often `{uuid}@sicksense.com`; geom Point 4326 |
+| Account identity | `sicksense`, `sicksense_users` | Real email/password, verify flag; links many devices → one account |
+| Auth | `accesstoken` | Token string + `userId` + `expired` |
+| Devices / push | `devices` | device token, platform, subscribe flags |
+| Symptoms catalog | `symptoms` | slug/`name`, `isILI`, `predefined` |
+| Reports | `reports`, `reportssymptoms` | health reports + M2M symptoms; geom; week/year; ILI flags |
+| Locations | `locations` | Thailand admin levels + geom; report `location_id` |
+| Aggregates | `reports_summary_by_week`, `symptoms_summary_by_week` | Dashboard rollups / triggers |
+| Notifications | (messages/notifications tables) | Targeted push campaigns |
+| News | `news` | CMS-like posts |
+| Email subscription | `email_subscription` | Mailgun bounce/unsub handling |
+| One-time tokens | `onetimetoken` | verify / reset password flows |
+| ILI external series | `ililog` | imported ILI values by week |
+
+## Spatial
+
+- SRID **4326**
+- User/report points: `Geometry(Point, 4326)` / WKT insert pattern `SRID=4326;POINT(...)`
+- Geo filter on reports uses `ST_Within` + polygon from SW/NE corners
+
+## Config-driven domain
+
+| Config | Role |
+|--------|------|
+| `config/symptoms.js` | Canonical symptom slugs + ILI symptom set |
+| `config/session.js` `secret` | Password hashing salt material (`password-hash-and-salt`) |
+| `config/sharedTokens` | Server-to-server `token` query values |
+| `config/mailgun` | API + webhook token |

--- a/docs/migration/GFV_F1_CROSSTAB_VERIFY.md
+++ b/docs/migration/GFV_F1_CROSSTAB_VERIFY.md
@@ -1,0 +1,300 @@
+# GFV F1 Verification — single-arg `crosstab(text)` symptom mis-mapping
+
+- **Task**: `gfv-f1-verify-fable` — read-only production verification of finding F1
+- **Verdict**: **CONFIRMED**
+- **Confidence**: **5 / 5**
+- **Verified on**: 2026-07-31 (Asia/Bangkok), host `api.sicksense.org`, PostgreSQL 9.3.17
+- **Method**: SELECT-only SQL over prod DBs `sicksense` and `globalfluview` (same cluster, user `sicksense`), executed via SSH with `SET default_transaction_read_only = on` as an extra guard. DB password was extracted on the remote host from `config/local.js` into `PGPASSWORD` inside the same remote shell; it was never printed, never left the host, and appears nowhere in this repo. No `CREATE EXTENSION` was run (`tablefunc 1.0` already installed — the sync itself installs it, see side findings). No PII beyond truncated symptom-name text in a ≤20-row sample; no lat/lon/email selected anywhere.
+
+## TL;DR
+
+The hypothesis is correct and now proven at both ends of the pipeline. PostgreSQL's single-arg `crosstab(text)` ignores the category (symptom-name) column and fills the declared output columns left-to-right. Because the sync feeds a constant `1` as the value, the stored "symptom" columns degrade into pure **symptom-count thresholds**:
+
+| stored column | actually means |
+|---|---|
+| `sym_fever = 1` | report has **≥ 1** symptom row (of any kind) |
+| `sym_cough = 1` | report has **≥ 2** symptom rows |
+| `sym_headache = 1` | report has **≥ 4** symptom rows |
+| `sym_sore_throat = 1` | report has **≥ 6** symptom rows |
+| `is_ili = true` | report has **≥ 1** symptom row of any kind |
+
+This held with **zero exceptions across 1,048,565 production reports** when running the sync's exact crosstab SQL (`mechanism_violations = 0`), and the **entire globalfluview dataset (102,880 surveys, 216 weeks)** is exactly threshold-shaped (`is_ili ≡ sym_fever`, `sore ⊆ headache ⊆ cough ⊆ fever`, 0 violations). ILI is inflated ~2.8× over all history (~4× in the current era); fever is inflated ~12×; more than half of true sore-throat reports are dropped. A second, independent defect was found: the live app has stopped using the 2014 catalog names — it writes Thai display-text symptom names — so even a label-correct pivot would miss ~90% of real symptoms today.
+
+---
+
+## 1. Mechanism (Q0 + real crosstab run)
+
+### 1.1 Symptom catalog (Q0)
+
+`symptoms` holds **14,021 rows**: ids 1–13 are the fixed catalog, everything above is user/free-text (Thai phrases, junk like `x`, `yyyjhf`, drug names). DB collation `en_US.UTF-8`. No duplicate names among the 13 catalog names.
+
+| id | name | | id | name |
+|---|---|---|---|---|
+| 1 | fever | | 8 | jointache |
+| 2 | cough | | 9 | diarrhea |
+| 3 | nuasea | | 10 | dark-urine |
+| 4 | headache | | 11 | bleeding |
+| 5 | red-eye | | 12 | imfine |
+| 6 | sore-throat | | 13 | aphthous |
+
+The sync declares columns `(report_id, fever, cough, nuasea, headache, "red-eye", "sore-throat", rash, jointache, diarrhea, imfine)` — i.e. id order (1–9, 12) — while the inner query is `ORDER BY 1, 2`, i.e. **alphabetical by name** over all 14,021 names. Declaration order ≠ feed order, and single-arg `crosstab` never matches labels anyway: per the PostgreSQL docs it "fills the output value columns, left to right, with the value fields from these rows"; extra rows beyond 10 are silently dropped. Since every value is the constant `1`, which column receives `1` depends **only on how many symptom rows the report has** — thresholds 1/2/3/4/5/6/… for fever/cough/nuasea/headache/red-eye/sore-throat/…
+
+`reportssymptoms` split: 207,352 rows reference catalog ids (≤13); 379,461 rows reference free-text ids (>13) — 65% of all symptom rows never had a corresponding output column even in theory.
+
+### 1.2 Empirical proof on production data
+
+I ran the sync's **exact** crosstab SQL (same string, same declared columns) joined with the sync's exact join conditions (`reports ⋈ locations ⋈ users(birthYear>0) ⟕ ct`), against ground truth computed per report with `bool_or(s.name = '<symptom>')`, plus a per-row mechanism check `col_k = 1 ⇔ n_syms ≥ k` for k ∈ {1,2,4,6}:
+
+- **`mechanism_violations = 0`** over all **1,048,399** joined reports (global) and all **166** reports of the test window. The count-threshold semantics is exact, not approximate.
+- Cross-check identities (global): `ct_fever 238,536 = syms≥1 (119,867+51,231+27,606+25,164+14,668)`; `ct_headache 39,832 = syms≥4 (25,164+14,668)`; `ct_sore 14,668 = syms≥6` — the stored columns are literally the tail-sums of the symptom-count histogram.
+
+## 2. Corruption magnitude (Q1)
+
+### 2.1 Global — all history through the sync's joins (n = 1,048,399 reports; 809,863 have no symptom rows)
+
+| measure | crosstab (what sync stores) | truth (by catalog name) | false pos | false neg | distortion |
+|---|---:|---:|---:|---:|---|
+| fever | 238,536 | 19,867 | 218,669 | 0 | **12.0× inflated** |
+| cough | 118,669 | 33,278 | 93,414 | 8,023 | 3.6× inflated, 24% of true cough missed |
+| headache | 39,832 | 42,420 | 25,608 | 28,196 | totals near parity but 64% of flags false and 66% of true missed |
+| sore-throat | 14,668 | 30,244 | 9,925 | 25,501 | **halved**; 84% of true sore-throat missed |
+| **is_ili** | **238,536 (22.8%)** | **84,424 (8.1%)** | **154,112** | **0** | **2.8× inflated; 64.6% of flagged ILI are false** |
+
+`ili_false_neg = 0` and `fever_false_neg = 0` are structural: any report with a true ILI symptom has ≥1 symptom row, so it always gets `fever = 1` → flagged. Note the truth column is itself an *under*count for recent years (see §4), so real-era inflation is worse.
+
+### 2.2 Test window — GFV week `20260719` (2026-07-19 00:00 → 2026-07-26 00:00 +07, inclusive, as the sync's `BETWEEN`)
+
+| measure | recomputed crosstab (today) | GFV stored | truth (catalog name) | Thai-equivalent truth |
+|---|---:|---:|---:|---:|
+| reports | 166 | 159 | — | — |
+| sym_fever | 27 | 23 | 0 | — |
+| sym_cough | 12 | 10 | 0 | — |
+| sym_headache | 1 | 1 | 1 | — |
+| sym_sore_throat | 0 | 0 | 2 | — |
+| is_ili | 27 | 23 | 3 (1.8%) | 7 (4.2%) |
+
+**Exact reconciliation**: 7 of today's 166 in-window reports were created **after** the window closed (`createdAt ≥ 2026-07-27 00:00+07`, last one 2026-07-30 08:33) — i.e. after the sync ran. 166 − 7 = **159 = the stored GFV record_count exactly**; the aggregate deltas (+4 fever, +2 cough, +4 ili, +0 headache/sore) are consistent with those 7 late reports. The stored GFV week is reproduced by this pipeline to the row count.
+
+Sample of mismatched reports in the window (LIMIT 20 run; excerpt; `st_*` = what sync stores, `t_*` = truth by name):
+
+| report_id | n_syms | actual symptoms (alphabetical, as crosstab feeds them) | stored | truth |
+|---|---|---|---|---|
+| 1131326 | 1 | มีไข้ (fever, Thai) | fever=1 | all false |
+| 1131283 | 1 | migraine | fever=1 | all false |
+| 1131270 | 4 | ไอ \| มีไข้ \| เจ็บคอ \| คัดจมูก (cough, fever, sore throat, stuffy nose — Thai) | fever=1, cough=1, headache=1 | all false |
+| 1131241 | 3 | ปวดหลัง ปวดเอว \| allergic-whether \| sore-throat | fever=1, cough=1, sore=NULL | sore-throat=true |
+| 1131208 | 3 | allergic-whether \| runny-nose \| sore-throat | fever=1, cough=1, sore=NULL | sore-throat=true |
+| 1131184 | 2 | ความดันต่ำ... \| headache | fever=1, cough=1, headache=NULL | headache=true |
+| 1131238 | 1 | ท้องผูก (constipation) | fever=1 | all false |
+
+Report 1131241/1131208 show the label inversion crisply: an actual `sore-throat` row is stored as `fever=1, cough=1, sore_throat=NULL`.
+
+## 3. globalfluview stored data (Q2)
+
+Accessible with the same credentials on the same cluster. Coverage: **216 weeks, `20210829` → `20260719`** (with a sync outage gap between `20250720` and `20260503`), 102,880 surveys.
+
+Whole-dataset structural check (all 102,880 rows):
+
+| check | violations |
+|---|---:|
+| `is_ili <> (sym_fever IS TRUE)` | **0** |
+| `sym_cough` without `sym_fever` | **0** |
+| `sym_headache` without `sym_cough` | **0** |
+| `sym_sore_throat` without `sym_headache` | **0** |
+
+Totals: ili = fever = 17,541 (17.1%); cough = 9,357; headache = 3,966; sore-throat = 1,714. Real epidemiological data could not produce a perfect `sore ⊆ headache ⊆ cough ⊆ fever` chain with `is_ili ≡ sym_fever` across five years and 102,880 rows; count-threshold semantics forces it. **Every stored GFV week since 2021 is corrupted.** Recent per-week aggregates (e.g. 20260719: n=159, fever=23=ili, cough=10, headache=1, sore=0) all show `ili_1 = fever_1` and the monotone chain.
+
+## 4. Additional findings beyond F1
+
+1. **Vocabulary drift (new, high impact for migration).** Since at least the 2026 restart era, the app writes Thai display-text symptom names (top names since 2026-05-03: ผื่นคัน 89, ปวดหลัง ปวดเอว 74, ปวดศีรษะ 50, ท้องเสีย 44, ท้องผูก 38, ไอ 34, คลื่นไส้ 33, เจ็บคอ 26 …) plus some new English slugs (`runny-nose`, `allergic-whether`, `stomachache`, `migraine`). Catalog names are nearly dead (`sore-throat` 7, `fever` 4, `headache` 4 rows). Modern era (since 2026-05-03, n=1,964 synced-shape reports): stored-ILI-equivalent 351 (17.9%), strict-catalog-name ILI 11 (0.6%), Thai-equivalent ILI ≈ 85 (4.3%, using {fever,cough,headache,sore-throat, มีไข้, ไข้, ตัวร้อน, ไอ, เจ็บคอ, ปวดศีรษะ, ปวดหัว}; slight undercount — variants like "ปวดศีรษะ (ปวดหัว)" not matched). **Even a label-correct pivot would miss ~90% of real symptoms today.** The export layer must map the live vocabulary, not the 2014 catalog.
+2. **"imfine" inflation sub-path refuted.** Healthy check-ins set `reports."isFine"` and write **no** `reportssymptoms` rows (808,762 of the 809,863 zero-symptom reports have `isFine = true`; `imfine_counted_as_ili = 0`; zero `isFine` reports have any symptom row). They are stored with NULL symptom flags and `is_ili = false` — correct by accident. The inflation comes from non-ILI *symptomatic* reports, not from "I'm fine" reports.
+3. **The sync mutates the source DB**: `fetch_report()` executes `CREATE EXTENSION IF NOT EXISTS tablefunc` on the production sicksense DB every run (which is why `tablefunc 1.0` is installed). A read path should not carry DDL.
+4. **Full-table pivot every run**: the crosstab subquery has no date filter — it pivots all 586,813 `reportssymptoms` rows weekly to extract ~160 reports.
+5. **Join drops ~83k reports silently**: `users."birthYear" > 0` plus the `locations` inner join exclude 82,999 of 1,131,398 reports (7.3%) from GFV entirely. A migration should make this exclusion policy explicit.
+6. **`BETWEEN` is inclusive on both ends**: a report at exactly Sunday 00:00:00+07 lands in two consecutive weeks. Minor, but worth fixing at port time.
+7. **Late-arriving reports are permanently missed**: reports for a window created after the Monday sync (7 in the test week, some as late as +4 days) never reach GFV, since each week is synced once.
+
+## 5. Implication for the migration (GFV as multi-outlet export layer)
+
+- **Do not port the crosstab.** Replace with plain conditional aggregation, e.g. `bool_or(s.name = ANY(mapping))` / `max(CASE WHEN s.name IN (...) THEN 1 END)` grouped by report — or aggregate in Python. No extension needed, no label ambiguity.
+- **Build a symptom-vocabulary mapping table** (current Thai display names + legacy slugs + free-text policy) → GFV fields. Without it, a "fixed" pivot still exports near-zero symptom signal (finding 4.1).
+- **Decide `is_ili` semantics explicitly** (strict fever/cough/headache/sore-throat by mapped vocabulary; today's stored definition is "any symptom at all").
+- **Plan a backfill**: all 216 stored GFV weeks are corrupted; after the port, recompute historical weeks from sicksense raw data (raw tables retain everything needed; this verification recomputed a stored week exactly).
+- Fix the side issues at port time: no DDL in sync, date-filter the aggregation, half-open week intervals, explicit exclusion policy, and consider a late-arrival re-sync window.
+
+## 6. Exact SQL run (credentials excluded)
+
+All statements ran under `SET default_transaction_read_only = on; SET statement_timeout = '540s';` as user `sicksense` via `psql -v ON_ERROR_STOP=1` on the prod host. Password handling: `export PGPASSWORD="$(node -e '...read config/local.js, print connections.postgresql.password...')"` executed on the remote host only.
+
+### 6.1 Smoke / catalog (DB `sicksense`)
+
+```sql
+SELECT current_database(), current_user, inet_server_addr(), version();
+SELECT datname FROM pg_database WHERE NOT datistemplate ORDER BY 1;
+SELECT extname, extversion FROM pg_extension WHERE extname = 'tablefunc';   -- Q3: exists (1.0); nothing created
+SELECT count(*) AS crosstab_functions FROM pg_proc WHERE proname = 'crosstab';
+SELECT (SELECT count(*) FROM reports)         AS reports,
+       (SELECT count(*) FROM reportssymptoms) AS reportssymptoms,
+       (SELECT count(*) FROM symptoms)        AS symptoms,
+       (SELECT count(*) FROM users)           AS users,
+       (SELECT count(*) FROM locations)       AS locations;
+SELECT id, name FROM symptoms ORDER BY id;      -- Q0a
+SELECT id, name FROM symptoms ORDER BY name;    -- Q0b
+SELECT min("startedAt" AT TIME ZONE 'Asia/Bangkok'), max("startedAt" AT TIME ZONE 'Asia/Bangkok') FROM reports;
+SHOW lc_collate;
+SELECT name, count(*) AS n_ids, min(id), max(id) FROM symptoms
+WHERE name IN ('fever','cough','nuasea','headache','red-eye','sore-throat','rash','jointache','diarrhea','imfine','dark-urine','bleeding','aphthous')
+GROUP BY name HAVING count(*) > 1 ORDER BY 1;
+SELECT sum(CASE WHEN "symptomId" <= 13 THEN 1 ELSE 0 END) AS catalog_rows,
+       sum(CASE WHEN "symptomId" >  13 THEN 1 ELSE 0 END) AS freetext_rows
+FROM reportssymptoms;
+```
+
+### 6.2 Main verification — real crosstab vs truth, window + global (DB `sicksense`, Q1)
+
+```sql
+WITH ct AS (SELECT * FROM crosstab(
+    'SELECT rs."reportId", s.name AS symptom_name, 1 AS value
+    FROM symptoms s, reportssymptoms rs
+    WHERE s.id = rs."symptomId"
+    ORDER BY 1, 2'
+) AS ct(report_id int, fever int, cough int, nuasea int, headache int, "red-eye" int,
+        "sore-throat" int, rash int, jointache int, diarrhea int, imfine int)),
+truth AS (
+  SELECT rs."reportId" AS report_id,
+         count(*) AS n_syms,
+         bool_or(s.name = 'fever')       AS t_fever,
+         bool_or(s.name = 'cough')       AS t_cough,
+         bool_or(s.name = 'headache')    AS t_headache,
+         bool_or(s.name = 'sore-throat') AS t_sore,
+         bool_or(s.id = 12)              AS t_imfine
+  FROM reportssymptoms rs JOIN symptoms s ON s.id = rs."symptomId"
+  GROUP BY rs."reportId"
+),
+base AS (
+  SELECT r.id,
+         (r."startedAt" BETWEEN '2026-07-19 00:00:00+07' AND '2026-07-26 00:00:00+07') AS in_win,
+         coalesce(r."isFine", false) AS is_fine,
+         ct.fever AS c_fever, ct.cough AS c_cough, ct.headache AS c_headache, ct."sore-throat" AS c_sore,
+         coalesce(ct.fever = 1 OR ct.cough = 1 OR ct.headache = 1 OR ct."sore-throat" = 1, false) AS c_ili,
+         coalesce(t.n_syms, 0) AS n_syms,
+         coalesce(t.t_fever, false)    AS t_fever,
+         coalesce(t.t_cough, false)    AS t_cough,
+         coalesce(t.t_headache, false) AS t_headache,
+         coalesce(t.t_sore, false)     AS t_sore,
+         coalesce(t.t_imfine, false)   AS t_imfine,
+         (coalesce(t.t_fever,false) OR coalesce(t.t_cough,false) OR coalesce(t.t_headache,false) OR coalesce(t.t_sore,false)) AS t_ili
+  FROM reports r
+  JOIN locations l ON r.location_id = l.id
+  JOIN users u ON r."userId" = u.id AND u."birthYear" > 0
+  LEFT JOIN ct ON r.id = ct.report_id
+  LEFT JOIN truth t ON r.id = t.report_id
+)
+SELECT in_win, count(*) AS n_reports,
+       sum(CASE WHEN c_fever = 1 THEN 1 ELSE 0 END)    AS ct_fever,
+       sum(CASE WHEN c_cough = 1 THEN 1 ELSE 0 END)    AS ct_cough,
+       sum(CASE WHEN c_headache = 1 THEN 1 ELSE 0 END) AS ct_headache,
+       sum(CASE WHEN c_sore = 1 THEN 1 ELSE 0 END)     AS ct_sore,
+       sum(CASE WHEN c_ili THEN 1 ELSE 0 END)          AS ct_ili,
+       sum(CASE WHEN t_fever THEN 1 ELSE 0 END)    AS true_fever,
+       sum(CASE WHEN t_cough THEN 1 ELSE 0 END)    AS true_cough,
+       sum(CASE WHEN t_headache THEN 1 ELSE 0 END) AS true_headache,
+       sum(CASE WHEN t_sore THEN 1 ELSE 0 END)     AS true_sore,
+       sum(CASE WHEN t_ili THEN 1 ELSE 0 END)      AS true_ili,
+       sum(CASE WHEN c_fever = 1 AND NOT t_fever THEN 1 ELSE 0 END)                  AS fever_false_pos,
+       sum(CASE WHEN c_fever IS DISTINCT FROM 1 AND t_fever THEN 1 ELSE 0 END)       AS fever_false_neg,
+       sum(CASE WHEN c_cough = 1 AND NOT t_cough THEN 1 ELSE 0 END)                  AS cough_false_pos,
+       sum(CASE WHEN c_cough IS DISTINCT FROM 1 AND t_cough THEN 1 ELSE 0 END)       AS cough_false_neg,
+       sum(CASE WHEN c_headache = 1 AND NOT t_headache THEN 1 ELSE 0 END)            AS headache_false_pos,
+       sum(CASE WHEN c_headache IS DISTINCT FROM 1 AND t_headache THEN 1 ELSE 0 END) AS headache_false_neg,
+       sum(CASE WHEN c_sore = 1 AND NOT t_sore THEN 1 ELSE 0 END)                    AS sore_false_pos,
+       sum(CASE WHEN c_sore IS DISTINCT FROM 1 AND t_sore THEN 1 ELSE 0 END)         AS sore_false_neg,
+       sum(CASE WHEN c_ili AND NOT t_ili THEN 1 ELSE 0 END) AS ili_false_pos,
+       sum(CASE WHEN NOT c_ili AND t_ili THEN 1 ELSE 0 END) AS ili_false_neg,
+       sum(CASE WHEN c_ili AND t_imfine AND NOT t_ili THEN 1 ELSE 0 END) AS imfine_counted_as_ili,
+       sum(CASE WHEN is_fine THEN 1 ELSE 0 END) AS isfine_flag_true,
+       sum(CASE WHEN is_fine AND c_ili THEN 1 ELSE 0 END) AS isfine_flag_counted_ili,
+       sum(CASE WHEN (c_fever IS NOT DISTINCT FROM 1) <> (n_syms >= 1)
+              OR (c_cough IS NOT DISTINCT FROM 1) <> (n_syms >= 2)
+              OR (c_headache IS NOT DISTINCT FROM 1) <> (n_syms >= 4)
+              OR (c_sore IS NOT DISTINCT FROM 1) <> (n_syms >= 6)
+             THEN 1 ELSE 0 END) AS mechanism_violations,
+       sum(CASE WHEN n_syms = 0 THEN 1 ELSE 0 END) AS syms_0,
+       sum(CASE WHEN n_syms = 1 THEN 1 ELSE 0 END) AS syms_1,
+       sum(CASE WHEN n_syms = 2 THEN 1 ELSE 0 END) AS syms_2,
+       sum(CASE WHEN n_syms = 3 THEN 1 ELSE 0 END) AS syms_3,
+       sum(CASE WHEN n_syms IN (4,5) THEN 1 ELSE 0 END) AS syms_4_5,
+       sum(CASE WHEN n_syms >= 6 THEN 1 ELSE 0 END) AS syms_6_plus
+FROM base GROUP BY in_win ORDER BY in_win;
+```
+
+Sample queries (window-restricted, `LIMIT 20` / `LIMIT 8`) reused the `truth` CTE with
+`array_to_string(array_agg(substr(s.name,1,30) ORDER BY s.name), ' | ')` and filters
+`(n_syms>=1) <> t_fever OR (n_syms>=2) <> t_cough OR (n_syms>=4) <> t_headache OR (n_syms>=6) <> t_sore`
+and `t_imfine AND NOT (t_fever OR t_cough OR t_headache OR t_sore)` (the latter returned 0 rows).
+
+### 6.3 Vocabulary / reconciliation (DB `sicksense`)
+
+```sql
+SELECT substr(s.name,1,40) AS name, (s.id <= 13) AS catalog_sym, count(*) AS n
+FROM reportssymptoms rs
+JOIN symptoms s ON s.id = rs."symptomId"
+JOIN reports r ON r.id = rs."reportId"
+WHERE r."startedAt" >= '2026-05-03 00:00:00+07'
+GROUP BY 1, 2 ORDER BY n DESC LIMIT 30;
+
+SELECT (r."startedAt" BETWEEN '2026-07-19 00:00:00+07' AND '2026-07-26 00:00:00+07') AS in_win_20260719,
+       count(*) AS n,
+       sum(CASE WHEN t.n_syms >= 1 THEN 1 ELSE 0 END) AS stored_ili_eq_any_symptom,
+       sum(CASE WHEN t.strict_ili THEN 1 ELSE 0 END)  AS strict_name_ili,
+       sum(CASE WHEN t.thai_ili THEN 1 ELSE 0 END)    AS thai_equiv_ili
+FROM reports r
+JOIN locations l ON r.location_id = l.id
+JOIN users u ON r."userId" = u.id AND u."birthYear" > 0
+LEFT JOIN (SELECT rs."reportId" AS id, count(*) AS n_syms,
+             bool_or(s.name IN ('fever','cough','headache','sore-throat')) AS strict_ili,
+             bool_or(s.name IN ('fever','cough','headache','sore-throat',
+                                'มีไข้','ไข้','ตัวร้อน','ไอ','เจ็บคอ','ปวดศีรษะ','ปวดหัว')) AS thai_ili
+           FROM reportssymptoms rs JOIN symptoms s ON s.id = rs."symptomId"
+           GROUP BY rs."reportId") t ON t.id = r.id
+WHERE r."startedAt" >= '2026-05-03 00:00:00+07'
+GROUP BY 1 ORDER BY 1;
+
+SELECT count(*) AS in_win_total,
+       sum(CASE WHEN r."createdAt" >= '2026-07-27 00:00:00+07' THEN 1 ELSE 0 END) AS created_after_win_end,
+       min(r."createdAt" AT TIME ZONE 'Asia/Bangkok') AS first_created,
+       max(r."createdAt" AT TIME ZONE 'Asia/Bangkok') AS last_created
+FROM reports r
+JOIN locations l ON r.location_id = l.id
+JOIN users u ON r."userId" = u.id AND u."birthYear" > 0
+WHERE r."startedAt" BETWEEN '2026-07-19 00:00:00+07' AND '2026-07-26 00:00:00+07';
+```
+
+### 6.4 globalfluview checks (DB `globalfluview`, Q2)
+
+```sql
+SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY 1;
+SELECT id, from_date, through_date, record_count FROM sicksense_week ORDER BY id DESC LIMIT 15;
+SELECT count(*) FROM sicksense_survey;
+SELECT s.week_id, count(*) AS n,
+       sum(CASE WHEN s.sym_fever       THEN 1 ELSE 0 END) AS fever_1,
+       sum(CASE WHEN s.sym_fever IS NULL THEN 1 ELSE 0 END) AS fever_null,
+       sum(CASE WHEN s.sym_cough       THEN 1 ELSE 0 END) AS cough_1,
+       sum(CASE WHEN s.sym_headache    THEN 1 ELSE 0 END) AS headache_1,
+       sum(CASE WHEN s.sym_sore_throat THEN 1 ELSE 0 END) AS sore_1,
+       sum(CASE WHEN s.is_ili          THEN 1 ELSE 0 END) AS ili_1
+FROM sicksense_survey s GROUP BY s.week_id ORDER BY s.week_id DESC LIMIT 12;
+
+SELECT count(*) AS surveys,
+       sum(CASE WHEN is_ili THEN 1 ELSE 0 END)           AS ili_1,
+       sum(CASE WHEN sym_fever THEN 1 ELSE 0 END)        AS fever_1,
+       sum(CASE WHEN sym_cough THEN 1 ELSE 0 END)        AS cough_1,
+       sum(CASE WHEN sym_headache THEN 1 ELSE 0 END)     AS headache_1,
+       sum(CASE WHEN sym_sore_throat THEN 1 ELSE 0 END)  AS sore_1,
+       sum(CASE WHEN is_ili <> (sym_fever IS TRUE) THEN 1 ELSE 0 END)                            AS viol_ili_ne_fever,
+       sum(CASE WHEN (sym_cough IS TRUE) AND NOT (sym_fever IS TRUE) THEN 1 ELSE 0 END)          AS viol_cough_wo_fever,
+       sum(CASE WHEN (sym_headache IS TRUE) AND NOT (sym_cough IS TRUE) THEN 1 ELSE 0 END)       AS viol_headache_wo_cough,
+       sum(CASE WHEN (sym_sore_throat IS TRUE) AND NOT (sym_headache IS TRUE) THEN 1 ELSE 0 END) AS viol_sore_wo_headache
+FROM sicksense_survey;
+SELECT min(id) AS first_week, max(id) AS last_week, count(*) AS n_weeks FROM sicksense_week;
+```

--- a/docs/migration/GFV_F1_CROSSTAB_VERIFY.md
+++ b/docs/migration/GFV_F1_CROSSTAB_VERIFY.md
@@ -119,7 +119,7 @@ Totals: ili = fever = 17,541 (17.1%); cough = 9,357; headache = 3,966; sore-thro
 - **Do not port the crosstab.** Replace with plain conditional aggregation, e.g. `bool_or(s.name = ANY(mapping))` / `max(CASE WHEN s.name IN (...) THEN 1 END)` grouped by report — or aggregate in Python. No extension needed, no label ambiguity.
 - **Build a symptom-vocabulary mapping table** (current Thai display names + legacy slugs + free-text policy) → GFV fields. Without it, a "fixed" pivot still exports near-zero symptom signal (finding 4.1).
 - **Decide `is_ili` semantics explicitly** (strict fever/cough/headache/sore-throat by mapped vocabulary; today's stored definition is "any symptom at all").
-- **Plan a backfill**: all 216 stored GFV weeks are corrupted; after the port, recompute historical weeks from sicksense raw data (raw tables retain everything needed; this verification recomputed a stored week exactly).
+- **Plan a backfill (owner chose option A)**: all 216 stored GFV weeks are corrupted; after the port, recompute **all** historical weeks from sicksense raw data and republish — see [ADR-003](./ADR-003-gfv-history-reexport.md). Raw tables retain everything needed; this verification recomputed a stored week exactly.
 - Fix the side issues at port time: no DDL in sync, date-filter the aggregation, half-open week intervals, explicit exclusion policy, and consider a late-arrival re-sync window.
 
 ## 6. Exact SQL run (credentials excluded)

--- a/docs/migration/GLOBAL_FLU_VIEW.md
+++ b/docs/migration/GLOBAL_FLU_VIEW.md
@@ -1,0 +1,112 @@
+# Global Flu View (GFV) — topology + migration scope
+
+Independent reviews (2026-07-31): **Grok**, **Claude Fable max**, **Codex Sol ultra**.  
+F1 live SQL verification: **CONFIRMED** — [GFV_F1_CROSSTAB_VERIFY.md](./GFV_F1_CROSSTAB_VERIFY.md) (Fable Max, 2026-07-31).  
+Evidence packet (local): `.grok/orchestration/packets/gfv-evidence-20260731.md`  
+Sibling repo (local): `../sicksense_globalfluview`  
+Remote: `git@bitbucket.org:opendream/sicksense_globalfluview.git`
+
+## Product decisions (owner)
+
+| Decision | Choice | Date |
+|----------|--------|------|
+| GFV / IWOPS data owner | Project owner (holds Django Basic credentials) | 2026-07-31 |
+| Historical DNS `api_globalfluview.sicksense.org` | **Not fulfilled** (still NXDOMAIN); path deploy is live; leave closed unless a **hyphenated** hostname is explicitly needed later | 2026-07-31 |
+| Final migration target | GFV **is in scope** for the new Python codebase as a **multi-outlet export API** (IWOPS/GFV first; other outlets later) — not left on eternal separate Django | 2026-07-31 |
+| Interim (during mobile rewrite) | Keep live Django path working; do not break cron/sync; port GFV into unified service **after or in a late phase** of main API migration | 2026-07-31 |
+
+## Current production verdict
+
+| Question | Answer |
+|----------|--------|
+| In sicksense Sails tree? | **No** |
+| What is it today? | Separate **Django 3.2** app (Python 3.6.15 + uWSGI + supervisor) |
+| Live URL | `https://api.sicksense.org/globalfluview/api/...` (path mount) |
+| Planned DNS `api_globalfluview.sicksense.org` | **NXDOMAIN** (request from years ago never completed as DNS; subpath used instead) |
+| Same host as main API? | **Yes** — `128.199.146.179` |
+
+## Production topology (today)
+
+```
+api.sicksense.org (nginx)
+  location /globalfluview*  → unix:/tmp/globalfluview.sock → Django GFV
+  location /                → forever Sails cluster
+DB: globalfluview (Django)  ← weekly sync_from_sicksense ← DB: sicksense
+Cron (opendream): Mon 09:00  manage.py sync_from_sicksense
+```
+
+Auth on GFV paths is **Django HTTP Basic** (`BASIC_AUTH_REALM = sicksense`), not nginx host-wide basic (nginx basic wraps only `location = /`).
+
+## Endpoints (Iwops v2 wire contract)
+
+| Method | Path | Auth | Notes |
+|--------|------|------|--------|
+| GET | `/globalfluview/api/weeks/` | HTTP Basic | Week list |
+| GET | `/globalfluview/api/surveys/{week_id}/` | HTTP Basic | lat/lon, symptoms, IsILI |
+| GET | `/globalfluview/api/participants/{week_id}/` | HTTP Basic | gender, birthYear |
+| — | `/globalfluview/admin/` | Django admin | Not part of public outlet contract |
+
+Wire format: `{ "Iwops": "v2", "Resource": "...", "Data": [...] }` — **not** Sails `{meta, response}`.
+
+Live field quirks (freeze via golden fixtures when porting): `WeekId`/`SubmitDate` strings; `IsILI`/`IsVax` booleans; `IsFinal` always 1; `BirthMonth` always 1; `CountryCode` always `"TH"`; `IsVax` always false from sync.
+
+## Historical DNS chat
+
+Request (paraphrase, long ago): add `api_globalfluview.sicksense.org` → same IP as `api.sicksense.org` for separate deploy.
+
+| Intent | Outcome |
+|--------|---------|
+| Separate process / deploy | **Done** (supervisor + own DB) |
+| Same IP | **Done** (path co-host) |
+| Dedicated DNS name | **Not done** (NXDOMAIN) — effectively superseded by path mount |
+
+**Policy:** do **not** create the underscored name for public HTTPS (invalid for normal public cert SANs). Path URL is the live contract. Optional later: `api-globalfluview.sicksense.org` only with cert + vhost plan.
+
+## Migration plan (revised)
+
+### Phase A — Mobile API rewrite (early/mid)
+
+- Implement Sails parity in FastAPI for mobile/web contracts.
+- **Do not drop** GFV: keep Django process + nginx `/globalfluview` + weekly sync until Phase B.
+- Cutover checklist must include: main schema still readable by sync; `tablefunc` if still used; host co-tenancy.
+
+### Phase B — Multi-outlet export in unified codebase (late / end state)
+
+Fold GFV into the **same** new Python service (or a tightly versioned module) as an **outlet**:
+
+| Concern | Approach |
+|---------|----------|
+| Routes | Preserve `/globalfluview/api/...` (or versioned equivalent with redirect) |
+| Auth | Basic for IWOPS; design for **multiple outlet credentials / scopes** later |
+| Envelope | Keep Iwops v2 for GFV outlet; other outlets may use different shapes |
+| Data path | Prefer **in-process / shared DB** or versioned export views — retire fragile dual-DB weekly `crosstab` sync when safe |
+| Symptom / ILI | Explicit outlet policy (see risks); do not silently match mobile ADR-002 without owner decision |
+| Expansion | Second system outlet = new adapter + auth + contract tests, not a third long-lived Django app |
+
+### Non-goals until Phase B
+
+- Re-implementing GFV inside mobile-only OpenAPI without multi-outlet design.
+- Dual-writing health POSTs through GFV.
+
+## Risks (pre-port)
+
+1. **crosstab(text) pivot — CONFIRMED** on prod (Fable Max): single-arg crosstab stores **symptom-count thresholds**, not named symptoms. Effective: `sym_fever`/`is_ili` ⇔ ≥1 any symptom; ILI ~**2.8×** inflated historically; all **216** stored GFV weeks structurally threshold-shaped. See [GFV_F1_CROSSTAB_VERIFY.md](./GFV_F1_CROSSTAB_VERIFY.md).
+2. **Vocabulary drift — CONFIRMED**: modern reports use Thai free-text / new slugs; catalog names nearly dead. Even a label-correct pivot would miss most current symptoms without a mapping table.
+3. **ILI definitions** — Sails ADR-002 vs GFV intended (+headache) vs stored effective **any symptom**.
+4. **Privacy** — exact lat/lon (home-address fallback), postal code, stable internal `users.id` as ParticipantId.
+5. **EOL stack** — Ubuntu 14.04 / Django 3.2 / Python 3.6 on shared box.
+6. **Sync ops** — weekly DDL `CREATE EXTENSION` on primary; full-table pivot; late reports missed; cron 09:00 vs docs 10:00.
+
+## Phase B port requirements (from F1)
+
+- Replace crosstab with conditional aggregation / Python mapping — **do not port crosstab**.
+- Symptom vocabulary map (Thai + legacy English + free-text policy).
+- Explicit outlet `is_ili` policy (owner decision).
+- Historical **backfill** of all GFV weeks from raw `sicksense` tables after correct extractor.
+- No DDL on read path; half-open week intervals; optional late-arrival re-sync.
+
+## Still open (product)
+
+- Whether to re-publish corrected historical weeks to external consumers (if any still read the feed).
+- Pseudonymize ParticipantId / reduce coordinate precision for new outlets.
+- Path-only forever vs optional hyphenated hostname.

--- a/docs/migration/GLOBAL_FLU_VIEW.md
+++ b/docs/migration/GLOBAL_FLU_VIEW.md
@@ -14,6 +14,7 @@ Remote: `git@bitbucket.org:opendream/sicksense_globalfluview.git`
 | Historical DNS `api_globalfluview.sicksense.org` | **Not fulfilled** (still NXDOMAIN); path deploy is live; leave closed unless a **hyphenated** hostname is explicitly needed later | 2026-07-31 |
 | Final migration target | GFV **is in scope** for the new Python codebase as a **multi-outlet export API** (IWOPS/GFV first; other outlets later) — not left on eternal separate Django | 2026-07-31 |
 | Interim (during mobile rewrite) | Keep live Django path working; do not break cron/sync; port GFV into unified service **after or in a late phase** of main API migration | 2026-07-31 |
+| Historical data after fix | **Option A** — recompute and republish **all** historical GFV weeks from raw `sicksense` data (not forward-only). See [ADR-003](./ADR-003-gfv-history-reexport.md) | 2026-07-31 |
 
 ## Current production verdict
 
@@ -102,11 +103,11 @@ Fold GFV into the **same** new Python service (or a tightly versioned module) as
 - Replace crosstab with conditional aggregation / Python mapping — **do not port crosstab**.
 - Symptom vocabulary map (Thai + legacy English + free-text policy).
 - Explicit outlet `is_ili` policy (owner decision).
-- Historical **backfill** of all GFV weeks from raw `sicksense` tables after correct extractor.
+- Historical **backfill of all weeks** from raw `sicksense` (**ADR-003 option A**): replay job + staged swap, not last-week-only cron.
 - No DDL on read path; half-open week intervals; optional late-arrival re-sync.
 
 ## Still open (product)
 
-- Whether to re-publish corrected historical weeks to external consumers (if any still read the feed).
+- Exact ILI + Thai/English symptom mapping table for replay (must be fixed **before** bulk re-export).
 - Pseudonymize ParticipantId / reduce coordinate precision for new outlets.
 - Path-only forever vs optional hyphenated hostname.

--- a/docs/migration/OPEN_QUESTIONS.md
+++ b/docs/migration/OPEN_QUESTIONS.md
@@ -11,7 +11,8 @@ Updated after independent Grok report + Fable Max + Codex Sol Ultra review.
 2. **Global Flu View / multi-outlet export** — **topology + ownership resolved (2026-07-31)**  
    Separate Django app path-mounted on `api.sicksense.org/globalfluview/*`; Basic auth; DNS `api_globalfluview` never created (NXDOMAIN). Owner holds Basic credentials. **Final target:** fold into unified Python codebase as multi-outlet API (Phase B); keep Django until then.  
    **F1:** crosstab corruption **CONFIRMED** ([GFV_F1_CROSSTAB_VERIFY.md](./GFV_F1_CROSSTAB_VERIFY.md)).  
-**Still open:** re-publish corrected history?; privacy precision for new outlets; active external pollers vs real consumers.  
+**History:** **re-export all weeks** accepted ([ADR-003](./ADR-003-gfv-history-reexport.md)).  
+**Still open:** symptom/ILI mapping for replay; privacy precision for new outlets; active external pollers vs real consumers.  
    **Docs:** [GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md).
 
 3. **Active consumers & app versions**  

--- a/docs/migration/OPEN_QUESTIONS.md
+++ b/docs/migration/OPEN_QUESTIONS.md
@@ -1,0 +1,30 @@
+# Open questions from code sweep
+
+1. **`POST /login` and `GET /reports`**  
+   Implemented in controllers and covered by tests/apiary, but **not** listed in `config/routes.js`, and blueprints (`actions`/`rest`/`shortcuts`) are **false**.  
+   → Confirm how production exposes them (missing routes, reverse-proxy rewrite, or dead code).
+
+2. **`LoginController.index`** vs **`connect`**  
+   Login (email/password) vs connect (link sicksense account to device uuid).  
+   → Confirm which path mobile 4.x+ uses.
+
+3. **Registration dual identity**  
+   Device user (`uuid@sicksense.com`) vs sicksense account email.  
+   → Document exact client fields (`uuid` vs `email`) for current app versions.
+
+4. **Dashboard**  
+   Only `GET /dashboard/now` is routed; controller also has other methods.  
+   → Confirm unused methods.
+
+5. **Error envelope**  
+   Thai vs English, and whether clients parse `invalidFields`.  
+   → Capture golden fixtures from tests.
+
+6. **Side effects**  
+   Mailgun, APNs, GCM — which must be real vs stubbed in Python for parity tests.
+
+7. **Cron endpoints**  
+   How often called, from where, and whether they should become workers instead of HTTP in Python.
+
+8. **Access token lifetime / refresh**  
+   Created on login/register; expiry rules for rewrite.

--- a/docs/migration/OPEN_QUESTIONS.md
+++ b/docs/migration/OPEN_QUESTIONS.md
@@ -1,30 +1,43 @@
-# Open questions from code sweep
+# Open questions from code sweep + multi-reviewer synthesis
 
-1. **`POST /login` and `GET /reports`**  
-   Implemented in controllers and covered by tests/apiary, but **not** listed in `config/routes.js`, and blueprints (`actions`/`rest`/`shortcuts`) are **false**.  
-   → Confirm how production exposes them (missing routes, reverse-proxy rewrite, or dead code).
+Updated after independent Grok report + Fable Max + Codex Sol Ultra review.
 
-2. **`LoginController.index`** vs **`connect`**  
-   Login (email/password) vs connect (link sicksense account to device uuid).  
-   → Confirm which path mobile 4.x+ uses.
+## Blockers for cutover (need production truth)
 
-3. **Registration dual identity**  
-   Device user (`uuid@sicksense.com`) vs sicksense account email.  
-   → Document exact client fields (`uuid` vs `email`) for current app versions.
+1. **Deployed route map**  
+   Confirm how (if at all) production exposes `POST /login`, `GET /reports`, `GET /dashboard` (controller `index` exists, only `GET /dashboard/now` is routed). Blueprints are off.  
+   **Verify:** nginx/proxy config, access logs, mobile traffic.
 
-4. **Dashboard**  
-   Only `GET /dashboard/now` is routed; controller also has other methods.  
-   → Confirm unused methods.
+2. **Global Flu View / external aggregators**  
+   Paths such as `/globalfluview/api/weeks/` and `/globalfluview/api/surveys/{week_id}/` are **not** in this repo. Live host may use host-wide basic auth (not GFV-specific).  
+   **Verify:** reverse proxy upstreams, separate services, authenticated fixtures — do **not** invent endpoints.
 
-5. **Error envelope**  
-   Thai vs English, and whether clients parse `invalidFields`.  
-   → Capture golden fixtures from tests.
+3. **Active consumers & app versions**  
+   DoctorMe / sicksense-web / external networks. Needed before changing `userReports` or dual-identity rules.
 
-6. **Side effects**  
-   Mailgun, APNs, GCM — which must be real vs stubbed in Python for parity tests.
+4. **Password hashing bit-compat**  
+   `password-hash-and-salt` with `sails.config.session.secret` as salt argument. Must match bit-exact at cutover or all logins fail.  
+   **Verify:** golden hash fixtures from known password + secret.
 
-7. **Cron endpoints**  
-   How often called, from where, and whether they should become workers instead of HTTP in Python.
+5. **Week / timezone**  
+   `moment(startedAt).week()` (locale-dependent) drives `year`/`week` on reports and summaries. Python ISO week may skew dashboards.  
+   **Verify:** unit fixtures for boundary dates (Bangkok TZ).
 
-8. **Access token lifetime / refresh**  
-   Created on login/register; expiry rules for rewrite.
+## Contract / inventory quality
+
+6. **Error wire format**  
+   400 often has rich `meta`; 404/500 may not share the same envelope (see `api/responses/*`). Need golden captures.
+
+7. **Apiary drift**  
+   `apiary.apib` documents some routes/tests that disagree with `routes.js` (e.g. `GET /reports/{id}`). Treat as **stale evidence**, not law.
+
+8. **Trigger semantics**  
+   Summary tables updated by plpgsql; fine/sick exclusivity per user/week/location may live in triggers. Port or replace only after reading `db/3_*` and `db/16_*`.
+
+## Product decisions (ADRs)
+
+| Topic | Doc | Status |
+|-------|-----|--------|
+| `userReports` global page vs filter by user | [ADR-001](./ADR-001-userReports-behavior.md) | Doc accepted; fix-vs-parity open |
+| ILI any-of vs fever+respiratory | [ADR-002](./ADR-002-ili-rule.md) | **Code rule accepted** |
+| Dual-write cutover | — | Prefer **single writer** + shadow reads (Codex); avoid nginx dual-write for POST health data |

--- a/docs/migration/OPEN_QUESTIONS.md
+++ b/docs/migration/OPEN_QUESTIONS.md
@@ -8,9 +8,11 @@ Updated after independent Grok report + Fable Max + Codex Sol Ultra review.
    Confirm how (if at all) production exposes `POST /login`, `GET /reports`, `GET /dashboard` (controller `index` exists, only `GET /dashboard/now` is routed). Blueprints are off.  
    **Verify:** nginx/proxy config, access logs, mobile traffic.
 
-2. **Global Flu View / external aggregators**  
-   Paths such as `/globalfluview/api/weeks/` and `/globalfluview/api/surveys/{week_id}/` are **not** in this repo. Live host may use host-wide basic auth (not GFV-specific).  
-   **Verify:** reverse proxy upstreams, separate services, authenticated fixtures — do **not** invent endpoints.
+2. **Global Flu View / multi-outlet export** — **topology + ownership resolved (2026-07-31)**  
+   Separate Django app path-mounted on `api.sicksense.org/globalfluview/*`; Basic auth; DNS `api_globalfluview` never created (NXDOMAIN). Owner holds Basic credentials. **Final target:** fold into unified Python codebase as multi-outlet API (Phase B); keep Django until then.  
+   **F1:** crosstab corruption **CONFIRMED** ([GFV_F1_CROSSTAB_VERIFY.md](./GFV_F1_CROSSTAB_VERIFY.md)).  
+**Still open:** re-publish corrected history?; privacy precision for new outlets; active external pollers vs real consumers.  
+   **Docs:** [GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md).
 
 3. **Active consumers & app versions**  
    DoctorMe / sicksense-web / external networks. Needed before changing `userReports` or dual-identity rules.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,26 @@
+# Sicksense → Python + modern Postgres migration
+
+## Goals (locked)
+
+| Decision | Choice |
+|----------|--------|
+| API | **Faithful parity** with current mobile/web contracts |
+| Stack | **FastAPI + SQLAlchemy 2 + Alembic** |
+| Clients | Existing mobile / consumers must keep working |
+| Database | **PostgreSQL 16/17 + PostGIS**, migrate existing data |
+| This branch | **Full API surface inventory only** (no Python app yet) |
+
+## Documents
+
+| File | Purpose |
+|------|---------|
+| [API_INVENTORY.md](./API_INVENTORY.md) | Every endpoint: auth, inputs, outputs, notes |
+| [RESPONSE_ENVELOPE.md](./RESPONSE_ENVELOPE.md) | Shared success/error JSON shapes |
+| [DOMAIN_TABLES.md](./DOMAIN_TABLES.md) | High-level data domains vs tables (for PG migrate) |
+| [OPEN_QUESTIONS.md](./OPEN_QUESTIONS.md) | Ambiguities found while sweeping |
+
+## Next (not this PR)
+
+1. OpenAPI 3 draft generated from inventory + tests.
+2. Scaffold FastAPI service + Alembic against PG 16/17 PostGIS.
+3. Slice-by-slice parity (auth → users → reports → dashboard → admin/cron).

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -4,23 +4,34 @@
 
 | Decision | Choice |
 |----------|--------|
-| API | **Faithful parity** with current mobile/web contracts |
+| API | **Faithful API parity** with current mobile/web contracts |
 | Stack | **FastAPI + SQLAlchemy 2 + Alembic** |
 | Clients | Existing mobile / consumers must keep working |
 | Database | **PostgreSQL 16/17 + PostGIS**, migrate existing data |
-| This branch | **Full API surface inventory only** (no Python app yet) |
+| Inventory branch | Full API surface inventory (docs only) |
 
 ## Documents
 
 | File | Purpose |
 |------|---------|
-| [API_INVENTORY.md](./API_INVENTORY.md) | Every endpoint: auth, inputs, outputs, notes |
+| [API_INVENTORY.md](./API_INVENTORY.md) | Endpoints: auth, inputs, outputs, notes |
 | [RESPONSE_ENVELOPE.md](./RESPONSE_ENVELOPE.md) | Shared success/error JSON shapes |
-| [DOMAIN_TABLES.md](./DOMAIN_TABLES.md) | High-level data domains vs tables (for PG migrate) |
-| [OPEN_QUESTIONS.md](./OPEN_QUESTIONS.md) | Ambiguities found while sweeping |
+| [DOMAIN_TABLES.md](./DOMAIN_TABLES.md) | Domains ↔ tables / PostGIS / triggers |
+| [OPEN_QUESTIONS.md](./OPEN_QUESTIONS.md) | Blockers and product decisions |
+| [REVIEW_SYNTHESIS.md](./REVIEW_SYNTHESIS.md) | A vs B + Fable/Codex consensus |
+| [ADR-001-userReports-behavior.md](./ADR-001-userReports-behavior.md) | Global report list bug/behavior |
+| [ADR-002-ili-rule.md](./ADR-002-ili-rule.md) | ILI any-of rule |
 
-## Next (not this PR)
+## Consensus next steps
 
-1. OpenAPI 3 draft generated from inventory + tests.
-2. Scaffold FastAPI service + Alembic against PG 16/17 PostGIS.
-3. Slice-by-slice parity (auth → users → reports → dashboard → admin/cron).
+1. Prod nginx/route map (resolves unrouted paths + GFV ownership).  
+2. Golden wire fixtures (incl. **two users** for `userReports`).  
+3. Schema/trigger dump → PG 16/17 characterization.  
+4. Per-endpoint OpenAPI from inventory + fixtures.  
+5. FastAPI skeleton; slices: auth → reports → dashboard → admin/cron.
+
+## Explicit non-goals (until ADRs say otherwise)
+
+- Inventing Global Flu View routes without ops proof.  
+- Dual-writing POSTs to old and new backends.  
+- Blind major bumps (Sails 1 / Lodash 4) on the legacy Node app.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -24,6 +24,7 @@
 | [GFV_F1_CROSSTAB_VERIFY.md](./GFV_F1_CROSSTAB_VERIFY.md) | Prod SQL proof: crosstab symptom corruption (CONFIRMED) |
 | [ADR-001-userReports-behavior.md](./ADR-001-userReports-behavior.md) | Global report list bug/behavior |
 | [ADR-002-ili-rule.md](./ADR-002-ili-rule.md) | ILI any-of rule (Sails; GFV differs) |
+| [ADR-003-gfv-history-reexport.md](./ADR-003-gfv-history-reexport.md) | Rebuild all GFV historical weeks (option A) |
 
 ## Consensus next steps
 
@@ -31,7 +32,7 @@
 2. Schema/trigger dump → PG 16/17 characterization.  
 3. Mobile FastAPI slices: auth → reports → dashboard → admin/cron (keep GFV Django alive).  
 4. Cutover: main schema + GFV sync co-tenancy gates ([GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md)).  
-5. **Phase B:** port GFV into unified multi-outlet module; retire dual-DB sync when safe; design for additional outlets.
+5. **Phase B:** port GFV into unified multi-outlet module; **replay all historical weeks** (ADR-003); retire dual-DB sync when safe; design for additional outlets.
 
 ## Explicit non-goals (until ADRs say otherwise)
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -8,6 +8,7 @@
 | Stack | **FastAPI + SQLAlchemy 2 + Alembic** |
 | Clients | Existing mobile / consumers must keep working |
 | Database | **PostgreSQL 16/17 + PostGIS**, migrate existing data |
+| Outlets | **GFV / multi-outlet export in final codebase** (Phase B); live Django until then |
 | Inventory branch | Full API surface inventory (docs only) |
 
 ## Documents
@@ -19,19 +20,22 @@
 | [DOMAIN_TABLES.md](./DOMAIN_TABLES.md) | Domains ↔ tables / PostGIS / triggers |
 | [OPEN_QUESTIONS.md](./OPEN_QUESTIONS.md) | Blockers and product decisions |
 | [REVIEW_SYNTHESIS.md](./REVIEW_SYNTHESIS.md) | A vs B + Fable/Codex consensus |
+| [GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md) | GFV topology + multi-outlet Phase B scope |
+| [GFV_F1_CROSSTAB_VERIFY.md](./GFV_F1_CROSSTAB_VERIFY.md) | Prod SQL proof: crosstab symptom corruption (CONFIRMED) |
 | [ADR-001-userReports-behavior.md](./ADR-001-userReports-behavior.md) | Global report list bug/behavior |
-| [ADR-002-ili-rule.md](./ADR-002-ili-rule.md) | ILI any-of rule |
+| [ADR-002-ili-rule.md](./ADR-002-ili-rule.md) | ILI any-of rule (Sails; GFV differs) |
 
 ## Consensus next steps
 
-1. Prod nginx/route map (resolves unrouted paths + GFV ownership).  
-2. Golden wire fixtures (incl. **two users** for `userReports`).  
-3. Schema/trigger dump → PG 16/17 characterization.  
-4. Per-endpoint OpenAPI from inventory + fixtures.  
-5. FastAPI skeleton; slices: auth → reports → dashboard → admin/cron.
+1. Golden wire fixtures (incl. **two users** for `userReports`).  
+2. Schema/trigger dump → PG 16/17 characterization.  
+3. Mobile FastAPI slices: auth → reports → dashboard → admin/cron (keep GFV Django alive).  
+4. Cutover: main schema + GFV sync co-tenancy gates ([GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md)).  
+5. **Phase B:** port GFV into unified multi-outlet module; retire dual-DB sync when safe; design for additional outlets.
 
 ## Explicit non-goals (until ADRs say otherwise)
 
-- Inventing Global Flu View routes without ops proof.  
+- Dropping live `/globalfluview` before Phase B port is verified.  
 - Dual-writing POSTs to old and new backends.  
-- Blind major bumps (Sails 1 / Lodash 4) on the legacy Node app.
+- Blind major bumps (Sails 1 / Lodash 4) on the legacy Node app.  
+- Creating DNS `api_globalfluview.sicksense.org` (NXDOMAIN; path is live; underscore unsuitable for public TLS).

--- a/docs/migration/RESPONSE_ENVELOPE.md
+++ b/docs/migration/RESPONSE_ENVELOPE.md
@@ -1,0 +1,52 @@
+# Shared response envelope
+
+Source: `api/responses/ok.js` and siblings (`badRequest`, `forbidden`, `notFound`, `serverError`, `conflict`).
+
+## Success (HTTP 200)
+
+```json
+{
+  "meta": { "status": 200 },
+  "response": { }
+}
+```
+
+`response` is whatever the controller passes to `res.ok(data)`.
+
+## Client errors (typical)
+
+Controllers often return:
+
+```json
+{
+  "meta": {
+    "status": 400,
+    "errorType": "Bad Request",
+    "errorMessage": "<user-facing Thai or English>",
+    "developerMessage": "...",
+    "invalidFields": { }
+  }
+}
+```
+
+Exact fields vary by response helper; parity requires matching each helper in `api/responses/`.
+
+| Status | Helper | Typical use |
+|--------|--------|-------------|
+| 400 | `res.badRequest` | Validation (`express-validator`) |
+| 403 | `res.forbidden` | Auth failures, wrong token, bad credentials |
+| 404 | `res.notFound` | Missing news / notification |
+| 409 | `res.conflict` | Duplicate registration |
+| 500 | `res.serverError` | Unexpected / DB errors |
+
+Many error messages are **Thai** (and some English). Preserve strings for client display parity.
+
+## Auth transport (global)
+
+| Mechanism | How | Used by |
+|-----------|-----|---------|
+| User access token | Query `?accessToken=<token>` | `tokenAuth`, `optionalTokenAuth` |
+| Shared server token | Query `?token=<shared>` | `sharedToken` (admin/cron/news write) |
+| Mailgun token | Query `?token=<mailgun.token>` | email hooks/send |
+
+**Note:** Access tokens are **not** Bearer headers in this API; they are query params.

--- a/docs/migration/REVIEW_SYNTHESIS.md
+++ b/docs/migration/REVIEW_SYNTHESIS.md
@@ -23,7 +23,7 @@
 1. **`userReports`** documents **global** page + count (not filtered by user). See ADR-001.  
 2. **ILI** is **any-of** `{fever, cough, sore-throat}`. See ADR-002. Reject B’s “fever + respiratory” wording.  
 3. **Registration** required fields corrected (`email`/`password` required; uuid/demographics optional in validate).  
-4. **GFV** section: not in repo; do not invent; verify ops.  
+4. **GFV** section: originally “not in repo / verify ops” — **ops verified 2026-07-31** (see below).  
 5. **Cutover:** prefer single writer + shadow validation over nginx dual-write of POSTs (Codex).
 
 ## Divergences resolved
@@ -31,11 +31,25 @@
 | Topic | Winner | Note |
 |-------|--------|------|
 | userReports SQL | B + code | Privacy + parity decision |
-| ILI formula | Code (not B’s prose) | Any ILI symptom |
-| GFV in this app | Unproven | Not in tree |
+| ILI formula | Code (not B’s prose) | Any ILI symptom (Sails) |
+| GFV in this app | **Separate service** | Path-mounted Django; not Sails |
 | Contract field detail | A (fixed) | B lacked field matrices |
 | Migration phases | Merge | A inventory → B phases without dual-write |
 
+## GFV multi-review (2026-07-31)
+
+**Reviewers:** Grok + Fable Max + Codex Sol Ultra (independent).  
+**Doc:** [GLOBAL_FLU_VIEW.md](./GLOBAL_FLU_VIEW.md)
+
+| Topic | Review consensus | Owner update (same day) |
+|-------|------------------|-------------------------|
+| Topology | Separate Django/uWSGI under `api.sicksense.org/globalfluview/*`; own DB; weekly sync | Confirmed |
+| Historical DNS | Intent half-met; name NXDOMAIN | **Never fulfilled**; leave closed (path is live) |
+| Credentials / owner | Unknown | **Owner holds Basic** |
+| Mobile early phases | Keep separate; cutover dependency | Keep live Django during mobile rewrite |
+| Final codebase | Default “keep separate” | **Override:** GFV **in** unified multi-outlet Python service (Phase B) |
+| Highest risks | `crosstab` mis-map; privacy; EOL stack | **F1 CONFIRMED** (2.8× ILI inflate; all weeks corrupted) + vocab drift |
+
 ## Gaps still open
 
-See [OPEN_QUESTIONS.md](./OPEN_QUESTIONS.md): prod routes, password bit-compat, week/TZ, trigger dump, golden wires, consumers.
+See [OPEN_QUESTIONS.md](./OPEN_QUESTIONS.md): remaining Sails prod routes, password bit-compat, week/TZ, trigger dump, golden wires; GFV F1 data-quality + Phase B outlet design.

--- a/docs/migration/REVIEW_SYNTHESIS.md
+++ b/docs/migration/REVIEW_SYNTHESIS.md
@@ -1,0 +1,41 @@
+# Review synthesis: inventory A vs independent report B
+
+**Date:** 2026-07-31  
+**Reviewers:** Independent Grok report (B); Fable Max; Codex Sol Ultra; this inventory (A).
+
+## Verdict
+
+| Artifact | Role |
+|----------|------|
+| **A (`docs/migration/*`)** | Better **structure** for contracts (routes, policies, envelope). Required fixes applied below. |
+| **B (independent report)** | Better **risk radar** (userReports leak, GFV question, cutover narrative). Some claims wrong (ILI formula). |
+| **Neither alone** | Sufficient for coding FastAPI without golden fixtures + prod nginx truth. |
+
+## Agreement (keep)
+
+- Legacy Sails 0.10 / PostGIS / explicit routes / blueprints off.
+- Query-param auth; dual device + sicksense identity.
+- Target: FastAPI + SQLAlchemy 2 + Alembic + PG 16/17 PostGIS; client parity.
+- Unrouted anomalies: login / reports index (and dashboard index).
+
+## Corrections applied to A
+
+1. **`userReports`** documents **global** page + count (not filtered by user). See ADR-001.  
+2. **ILI** is **any-of** `{fever, cough, sore-throat}`. See ADR-002. Reject B’s “fever + respiratory” wording.  
+3. **Registration** required fields corrected (`email`/`password` required; uuid/demographics optional in validate).  
+4. **GFV** section: not in repo; do not invent; verify ops.  
+5. **Cutover:** prefer single writer + shadow validation over nginx dual-write of POSTs (Codex).
+
+## Divergences resolved
+
+| Topic | Winner | Note |
+|-------|--------|------|
+| userReports SQL | B + code | Privacy + parity decision |
+| ILI formula | Code (not B’s prose) | Any ILI symptom |
+| GFV in this app | Unproven | Not in tree |
+| Contract field detail | A (fixed) | B lacked field matrices |
+| Migration phases | Merge | A inventory → B phases without dual-write |
+
+## Gaps still open
+
+See [OPEN_QUESTIONS.md](./OPEN_QUESTIONS.md): prod routes, password bit-compat, week/TZ, trigger dump, golden wires, consumers.

--- a/ppos/exploration/INDEX.md
+++ b/ppos/exploration/INDEX.md
@@ -21,7 +21,8 @@ None active.
 
 <!-- Track unresolved questions from exploration -->
 
-1. (none yet)
+1. **GFV / multi-outlet ILI set** — mobile `{fever,cough,sore-throat}` vs GFV intent (+headache) vs other → wiki [U01](../wiki/unknown-U01-gfv-outlet-ili-rule.md)  
+2. **Symptom vocabulary map** (Thai free-text + English slugs → Sym* flags) for re-export → wiki [U02](../wiki/unknown-U02-gfv-symptom-vocabulary-map.md)
 
 ## Compile Checkpoints
 

--- a/ppos/exploration/sessions/2026-07-31-gfv-ili-vocab.md
+++ b/ppos/exploration/sessions/2026-07-31-gfv-ili-vocab.md
@@ -1,0 +1,22 @@
+# Exploration session — GFV ILI & symptom mapping
+
+**Date:** 2026-07-31  
+**Mode:** requirement-analysis (note for later confirmation)  
+**Human:** keep as PPOS items to confirm later (not resolved now)
+
+## Observations (stable enough to cite, not outlet decisions)
+
+- Sails ILI: any of slugs `fever|cough|sore-throat` (`config/symptoms.js`, ADR-002).  
+- GFV sync intends `fever|cough|headache|sore-throat` and recomputes; does not use `reports.isILI`.  
+- F1 prod verify: stored GFV flags corrupted by crosstab; effective any-symptom ILI.  
+- Prod symptom names drifted to Thai free-text; catalog-only match insufficient for re-export.  
+- Owner: historical re-export option A (ADR-003); GFV in Phase B multi-outlet codebase.
+
+## Open unknowns (promoted to wiki)
+
+- [U01](../../wiki/unknown-U01-gfv-outlet-ili-rule.md) — outlet ILI rule  
+- [U02](../../wiki/unknown-U02-gfv-symptom-vocabulary-map.md) — vocabulary map  
+
+## Not promoted as rules yet
+
+Outlet ILI and full mapping remain **unconfirmed** until owner chooses.

--- a/ppos/wiki/INDEX.md
+++ b/ppos/wiki/INDEX.md
@@ -49,7 +49,10 @@ None yet.
 
 <!-- Hidden assumptions, blockers, stubs -->
 
-None yet.
+| ID | Article | Status | Confirm before |
+|----|---------|--------|----------------|
+| U01 | [unknown-U01-gfv-outlet-ili-rule.md](./unknown-U01-gfv-outlet-ili-rule.md) | open | Phase B GFV outlet + historical re-export |
+| U02 | [unknown-U02-gfv-symptom-vocabulary-map.md](./unknown-U02-gfv-symptom-vocabulary-map.md) | open | Phase B re-export (depends on U01) |
 
 ---
 

--- a/ppos/wiki/unknown-U01-gfv-outlet-ili-rule.md
+++ b/ppos/wiki/unknown-U01-gfv-outlet-ili-rule.md
@@ -1,0 +1,31 @@
+# Unknown U01 — GFV / multi-outlet ILI rule
+
+**Status:** open  
+**Must confirm before:** Phase B GFV port and historical re-export (ADR-003 option A)  
+**Not blocking:** mobile FastAPI Phase A (Sails parity uses ADR-002)
+
+## Question
+
+Which **ILI set** should the GFV / multi-outlet export use when recomputing `IsILI`?
+
+## Known facts (do not treat as the outlet decision)
+
+| Source | Rule | Status |
+|--------|------|--------|
+| Sails mobile API | `isILI` = any of `{fever, cough, sore-throat}` by **slug** | Code truth; [docs/migration/ADR-002-ili-rule.md](../../docs/migration/ADR-002-ili-rule.md) |
+| GFV sync **code intent** | `is_ili` = any of `{fever, cough, headache, sore-throat}` by pivot columns | Differs: **includes headache**; ignores `reports.isILI` |
+| GFV **stored data today** | Effective ≈ “any symptom ≥ 1” | Bug (crosstab); [docs/migration/GFV_F1_CROSSTAB_VERIFY.md](../../docs/migration/GFV_F1_CROSSTAB_VERIFY.md) |
+
+## Options (for later confirmation)
+
+1. Match mobile ADR-002: `{fever, cough, sore-throat}` only  
+2. Keep GFV code intent: add `headache`  
+3. Other (e.g. classic fever + respiratory) — would need explicit product write-up  
+
+## Resolution
+
+- [ ] Owner confirms option  
+- [ ] Linked from Phase B plan / outlet contract tests  
+- [ ] Applied in re-export replay job  
+
+**Resolved:** _not yet_

--- a/ppos/wiki/unknown-U02-gfv-symptom-vocabulary-map.md
+++ b/ppos/wiki/unknown-U02-gfv-symptom-vocabulary-map.md
@@ -1,0 +1,54 @@
+# Unknown U02 — GFV symptom vocabulary mapping
+
+**Status:** open  
+**Must confirm before:** Phase B GFV re-export of all historical weeks (ADR-003)  
+**Depends on:** [unknown-U01-gfv-outlet-ili-rule.md](./unknown-U01-gfv-outlet-ili-rule.md) (ILI set uses mapped flags)
+
+## Question
+
+How do live `symptoms.name` values (English catalog slugs **and** Thai free-text **and** new slugs) map to GFV export flags?
+
+GFV fields that need a yes/no (or null) per survey:
+
+- `SymFever`, `SymCough`, `SymSoreThroat`, `SymHeadache`
+- (and any future outlet symptom fields)
+- plus `IsILI` once U01 is set, via mapped flags
+
+## Known facts
+
+1. **App config catalog** (`config/symptoms.js`): English **slug** + Thai **title** for predefined list; mobile ILI matches **slugs** only.  
+2. **Prod DB:** ~14k `symptoms` names; majority of `reportssymptoms` rows are free-text (id > 13), not the fixed catalog.  
+3. **Modern clients** often store Thai display text (e.g. `มีไข้`, `ไอ`, `เจ็บคอ`) instead of slugs `fever` / `cough` / `sore-throat`.  
+4. Matching **only** English catalog names undercounts modern data (~90% miss risk per F1).  
+5. Crosstab bug is separate; fixing labels without a vocab map is still insufficient.
+
+## Mapping table to confirm later
+
+| GFV flag | Provisional seed (not approved) | Confirm / extend |
+|----------|----------------------------------|------------------|
+| fever | `fever`, `มีไข้`, `ไข้`, `ตัวร้อน`, … | [ ] |
+| cough | `cough`, `ไอ`, … | [ ] |
+| sore-throat | `sore-throat`, `เจ็บคอ`, … | [ ] |
+| headache | `headache`, `ปวดหัว`, `ปวดศีรษะ`, … | [ ] |
+| ignore / other | free-text junk, drug names, `imfine` path, … | [ ] |
+
+Also confirm:
+
+- [ ] Case / punctuation / parenthetical variants (e.g. `ปวดศีรษะ (ปวดหัว)`)  
+- [ ] Policy for unmapped free-text (drop vs “other” vs fail closed)  
+- [ ] Whether main mobile create path still writes **slugs** while GFV reads **names** (dual-path consistency)
+
+## Evidence / links
+
+- [docs/migration/GLOBAL_FLU_VIEW.md](../../docs/migration/GLOBAL_FLU_VIEW.md)  
+- [docs/migration/GFV_F1_CROSSTAB_VERIFY.md](../../docs/migration/GFV_F1_CROSSTAB_VERIFY.md)  
+- [docs/migration/ADR-003-gfv-history-reexport.md](../../docs/migration/ADR-003-gfv-history-reexport.md)  
+- Sibling GFV: `../sicksense_globalfluview` `sync_from_sicksense.py`  
+
+## Resolution
+
+- [ ] Owner-approved mapping table (versioned in repo)  
+- [ ] Fixture tests for Thai + English + junk  
+- [ ] Used by historical replay (option A)  
+
+**Resolved:** _not yet_


### PR DESCRIPTION
## Summary

Inventory-only groundwork for a faithful rewrite (**FastAPI + SQLAlchemy 2 + Alembic**, Postgres 16/17 + PostGIS, existing mobile clients), plus resolved **Global Flu View** topology and data-quality findings.

```text
docs/migration/
  README.md                 # goals, phases, non-goals
  API_INVENTORY.md          # Sails endpoints + GFV as separate/path-mounted service
  RESPONSE_ENVELOPE.md
  DOMAIN_TABLES.md
  OPEN_QUESTIONS.md
  REVIEW_SYNTHESIS.md       # multi-model consensus
  GLOBAL_FLU_VIEW.md        # live Django path mount; multi-outlet Phase B target
  GFV_F1_CROSSTAB_VERIFY.md # prod SQL proof: crosstab corrupts symptoms/ILI
  ADR-001-userReports-behavior.md
  ADR-002-ili-rule.md       # Sails ILI any-of
```

### GFV (owner decisions)

| Item | Decision |
|------|----------|
| Historical DNS `api_globalfluview.sicksense.org` | **Never created** (NXDOMAIN); live path is `api.sicksense.org/globalfluview/*` |
| Auth owner | Project owner holds Django Basic credentials |
| Final codebase | GFV **in** unified multi-outlet export (Phase B); keep Django until then |
| F1 crosstab | **CONFIRMED** on prod — stored flags are symptom-count thresholds; ILI ~2.8× inflated; all 216 weeks corrupted; Thai vocab drift means catalog names nearly dead |

### Explicit non-goals in this PR

- Application code / schema changes
- Fixing GFV sync in production (documented only)
- Creating the underscored DNS name

## Test plan

- [x] Multi-model architecture review (Grok + Fable Max + Codex Sol Ultra)
- [x] Live DNS/HTTP + prod nginx path mount confirmed
- [x] Fable Max read-only prod SQL verification of crosstab (CONFIRMED, confidence 5/5)
- [ ] Human review of inventory + GFV Phase B scope before implementation branch